### PR TITLE
AR-689: Help convert simple bash library to python class

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ modprobe gpio-pcf857x
 echo pcf8574 0x38 > sys/bus/i2c/devices/i2c-0/new_device
 ```
 
-### example
+### example - bash
 
 requires running as root....
 
@@ -49,6 +49,60 @@ gpio_bounce 507
 gpio_show_all
 gpio_unexport_all
 ```
+
+### example - python
+
+Running on [Orange Pi PC](https://www.armbian.com/orange-pi-pc/); with 2 LEDs on gpio 12 and 13
+
+```sh
+sudo python3 lib/api.py -c /dev/gpiochip0 -l 12 13
+```
+
+Then, on the same device
+
+```sh
+curl localhost:5000/on
+curl localhost:5000/off
+```
+
+Or form an other device on the same network
+
+```sh
+curl orangepipc.local:5000/12/toggle
+curl orangepipc.local:5000/13/bounce
+curl orangepipc.local:5000/toggle
+curl -s orangepipc.local:5000/state | jq
+```
+
+```json
+{
+  "12": {
+    "active": "high",
+    "direction": "output",
+    "value": 0
+  },
+  "13": {
+    "active": "high",
+    "direction": "output",
+    "value": 1
+  }
+}
+```
+
+```sh
+curl orangepipc.local:5000/13/toggle
+curl -s orangepipc.local:5000/13/state | jq
+```
+
+```json
+{
+  "active": "high",
+  "direction": "output",
+  "value": 0
+}
+```
+
+routes */gpio-num/#* impacts a single gpio while */#* impacts all configured lines
 
 ## resources
 * https://www.ti.com/product/PCF8574

--- a/lib/python/api.py
+++ b/lib/python/api.py
@@ -1,0 +1,64 @@
+import argparse
+import gpio
+import http
+from flask import Flask, abort
+
+app = Flask(__name__)
+gpios = None
+
+@app.route("/on")
+def on():
+    gpios.set_all(True)
+    return '', http.HTTPStatus.NO_CONTENT
+
+@app.route("/off")
+def off():
+    gpios.set_all(False)
+    return '', http.HTTPStatus.NO_CONTENT
+
+@app.route("/toggle")
+def toggle_all():
+    gpios.toggle_all()
+    return '', http.HTTPStatus.NO_CONTENT
+
+@app.route("/<int:line>/toggle")
+def toggle(line):
+    try:
+        gpios.toggle(line)
+        return '', http.HTTPStatus.NO_CONTENT
+    except KeyError:
+        abort(http.HTTPStatus.NOT_FOUND)
+
+@app.route("/bounce")
+def bounce_all():
+    gpios.bounce_all(5)
+    return '', http.HTTPStatus.NO_CONTENT
+
+@app.route("/<int:line>/bounce")
+def bounce(line):
+    try:
+        gpios.bounce(line, 5)
+        return '', http.HTTPStatus.NO_CONTENT
+    except KeyError:
+        abort(http.HTTPStatus.NOT_FOUND)
+
+@app.route("/state")
+def state_all():
+    return gpios.get_all(), http.HTTPStatus.OK
+
+@app.route("/<int:line>/state")
+def state(line):
+    return gpios.get(line), http.HTTPStatus.OK
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Drive GPIOs')
+    parser.add_argument('--chip', '-c',
+        default = '/dev/gpiochip0', help='gpio chip device file')
+    parser.add_argument('--lines', '-l', nargs='+', type=int,
+        default = [0], help='gpio lines')
+
+    args = parser.parse_args()
+
+    gpios = gpio.armbianGpios(args.chip, args.lines)
+
+    app.run("0.0.0.0")

--- a/lib/python/gpio.py
+++ b/lib/python/gpio.py
@@ -1,0 +1,174 @@
+import gpiod
+import threading
+
+class armbianGpios():
+    """
+    A class used to manipulate gpios as outputs.
+
+    It uses gpiod. All lines are set to gpio output active high.
+    Once the class is instantiated, all lines are set to 0.
+
+    Attributes
+    ----------
+    chip : str
+        gpio chip device file path (e.g. /dev/gpiochip0)
+    lines : dict
+        a dictionnary associating a gpio line number to a gpiod line
+    timer : Threading.Timer
+        a timer to bounce lines
+time
+    Methods
+    -------
+    get_all()
+        Returns a dictionnary summuraizing the gpios line state
+    get(line)
+        Returns a dictionnary summuraizing the gpio `line` state
+    set_all(value)
+        Sets all lines to `value`
+    set(line, value)
+        Sets `line` to `value`
+    toggle_all()
+        Toggles all lines
+    toggle(line)
+        Toggles `line`
+    bounce_all(timeSec)
+        Toggles all lines for `timeSec` seconds
+    bounce(line, timeSec)
+        Toggles `line` for `timeSec` seconds
+
+    """
+    def __init__(self, chip, lines):
+        """
+        Parameters
+        ----------
+        chip : str
+            gpio chip device file path (e.g. /dev/gpiochip0)
+        lines : list of int
+            A list of gpio lines
+
+        """
+        self.chip = gpiod.chip(chip)
+        self.lines = dict()
+        self.timer = None
+
+        for l in lines:
+            line = self.chip.get_line(l)
+            self.lines[l] = line
+            config = gpiod.line_request()
+            config.consumer = "armbian-gpio"
+            config.request_type = gpiod.line_request.DIRECTION_OUTPUT
+            line.request(config)
+            line.set_value(0)
+
+    def get_all(self):
+        """
+        Returns
+        -------
+        state : a dictionnary of gpio lines attributes
+
+        """
+        state = dict()
+        for l in self.lines:
+            state[l] = self.get(l)
+        return state
+
+    def get(self, line):
+        """
+        Parameters
+        ----------
+        line : int
+            the line number to get info from
+        Returns
+        -------
+        state : a dictionnary of gpio `line` attributes
+
+        """
+        state = dict()
+        if self.lines[line].direction == gpiod.line.DIRECTION_INPUT:
+            state['direction'] = "input"
+        else:
+            state['direction'] = "output"
+        if self.lines[line].active_state == gpiod.line.ACTIVE_HIGH:
+            state['active'] = "high"
+        else:
+            state['active'] = "low"
+        state['value'] = self.lines[line].get_value()
+        return state
+
+    def set_all(self, value):
+        """
+        Parameters
+        ----------
+        value : int
+            the value to set for all lines (0 or 1)
+
+        """
+        for l in self.lines:
+            self.set(l, value)
+
+    def set(self, line, value):
+        """
+        Parameters
+        ----------
+        line : int
+            the line number to set
+        value : int
+            the value to set for `line` (0 or 1)
+
+        """
+        try:
+            self.lines[line].set_value(value)
+        except KeyError:
+            raise
+
+    def toggle_all(self):
+        for l in self.lines:
+            self.toggle(l)
+
+    def toggle(self, line):
+        """
+        Parameters
+        ----------
+        line : int
+            the line number to toggle
+
+        """
+        try:
+            self.set(line, not self.lines[line].get_value())
+        except KeyError:
+            raise
+
+    def bounce_all(self, timeSec):
+        """
+        Parameters
+        ----------
+        timeSec : int
+            the bounce time in second
+
+        """
+        if self.timer is not None:
+            if self.timer.is_alive():
+                return
+        self.toggle_all()
+        self.timer = threading.Timer(timeSec, self.toggle_all)
+        self.timer.start()
+
+    def bounce(self, line, timeSec):
+        """
+        Parameters
+        ----------
+        line : int
+            the line number to bounce
+        timeSec : int
+            the bounce time in second
+
+        """
+        if self.timer is not None:
+            if self.timer.is_alive():
+                return
+        try:
+            self.toggle(line)
+            self.timer = threading.Timer(timeSec, self.toggle, [line])
+            self.timer.start()
+        except KeyError:
+            raise


### PR DESCRIPTION
A (limited) python class to manage GPIOs, and a flask API that uses it.

- Uses [gpiod](https://pypi.org/project/gpiod/)
- Documented in README and as python docstrings
- Not tested on the pcf857x GPIO extender